### PR TITLE
Change uglifyjs package to uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "envify": "~1.2.0",
     "browserify": "~3.32.1",
     "connect-browserify": "~2.0.0",
-    "uglifyjs": "~2.3.6",
+    "uglify-js": "~2.4.13",
     "supervisor": "~0.5.7"
   },
   "scripts": {


### PR DESCRIPTION
The uglifyjs fork currently used doesn't include the `.bin/uglify` file which results in the `npm run build` command failing. This change uses the latest version of the official uglify package.

As far as i could tell there is no need for the forked version, uglify-js includes a `uglify-to-browserify` transform.
