### PR TITLE
Add NotFound handler

### DIFF
--- a/client.js
+++ b/client.js
@@ -11,6 +11,7 @@ var superagent  = require('superagent');
 
 var Pages       = ReactRouter.Pages;
 var Page        = ReactRouter.Page;
+var NotFound    = ReactRouter.NotFound;
 var Link        = ReactRouter.Link;
 
 ReactMount.allowFullPageRender = true;
@@ -67,6 +68,15 @@ var UserPage = React.createClass({
   }
 });
 
+var NotFoundHandler = React.createClass({
+
+  render: function() {
+    return (
+      <p>Page not found</p>
+    );
+  }
+});
+
 var App = React.createClass({
 
   render: function() {
@@ -79,6 +89,7 @@ var App = React.createClass({
         <Pages className="App" path={this.props.path}>
           <Page path="/" handler={MainPage} />
           <Page path="/users/:username" handler={UserPage} />
+          <NotFound handler={NotFoundHandler} />
         </Pages>
       </html>
     );


### PR DESCRIPTION
Out of the box, the request for /favicon.ico 404s and causes the console output to print an error:

```
TypeError: Cannot read property 'ref' of undefined
    at cloneWithProps (/Users/jxg/github/react-quickstart/node_modules/react/lib/cloneWithProps.js:41:19)
    at RouteRenderingMixin.renderRouteHandler (/Users/jxg/github/react-quickstart/node_modules/react-router-component/lib/RouteRenderingMixin.js:12:12)
    at boundMethod [as renderRouteHandler] (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactCompositeComponent.js:1434:21)
    at React.createClass.render (/Users/jxg/github/react-quickstart/node_modules/react-router-component/lib/Router.js:32:26)
    at ReactCompositeComponentMixin._renderValidatedComponent (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactCompositeComponent.js:1394:34)
    at null._renderValidatedComponent (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactPerf.js:57:21)
    at ReactCompositeComponentMixin.mountComponent (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactCompositeComponent.js:947:14)
    at null.mountComponent (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactPerf.js:57:21)
    at ReactMultiChild.Mixin.mountChildren (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactMultiChild.js:202:42)
    at ReactDOMComponent.Mixin._createContentMarkup (/Users/jxg/github/react-quickstart/node_modules/react/lib/ReactDOMComponent.js:198:32)
```

This happens because of this issue: https://github.com/andreypopp/react-router-component/issues/36
I think it's a good idea to add a default NotFound handler.
