### PR TITLE
make supervisor watch jsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "supervisor -i node_modules server.js",
+    "start": "supervisor -i node_modules -e js,jsx server.js",
     "build": "NODE_ENV=production browserify ./ | uglifyjs -cm 2>/dev/null > ./assets/bundle.js",
     "start-prod": "NODE_ENV=production node server.js",
     "clean": "rm -f ./assets/bundle.js"


### PR DESCRIPTION
```
  -e|--extensions <extensions>
    A comma-delimited list of file extensions to watch for changes.
    Used when --watch option includes folders
    Default is 'node,js'
```
