### PR TITLE
remove setting allowFullPageRender

### DIFF
--- a/client.js
+++ b/client.js
@@ -4,7 +4,6 @@
 
 
 var React       = require('react');
-var ReactMount  = require('react/lib/ReactMount');
 var ReactAsync  = require('react-async');
 var ReactRouter = require('react-router-component');
 var superagent  = require('superagent');
@@ -13,8 +12,6 @@ var Pages       = ReactRouter.Pages;
 var Page        = ReactRouter.Page;
 var NotFound    = ReactRouter.NotFound;
 var Link        = ReactRouter.Link;
-
-ReactMount.allowFullPageRender = true;
 
 var MainPage = React.createClass({
 


### PR DESCRIPTION
It seems to me that this is not required anymore. I couldn’t find this property in React’s or ReactMount’s current source code and it doesn’t break anything. There also seems to be no documentation about this property or I couldn’t find it. Please let me know if I'm mistaken.
